### PR TITLE
Streamlines processing workflow.

### DIFF
--- a/README
+++ b/README
@@ -1,17 +1,20 @@
-Convert SBE CTD data into engineering units
+General Utility for processing SBE Data
 
-usage: run.py [-h] [-o output file] [-d] [-w [dest dir]] hex File XMLCON File
+usage: run.py [-h] [-d] [-r] [-p iniFile] [-o destDir] [-w [destDir]]
+              hex File XMLCON File
 
 positional arguments:
-  hex File        the .hex data file to process
-  XMLCON File     the .XMLCON data file to process
+  hex File      the .hex data file to process
+  XMLCON File   the .XMLCON data file to process
 
 optional arguments:
-  -h, --help      show this help message and exit
-  -o output file  name and location of output file
-  -d, --debug     display debug messages
-  -w [dest dir]   build web viewer, optionally specify the destination
-                  directory for the webviewer files
+  -h, --help    show this help message and exit
+  -d, --debug   display debug messages
+  -r, --raw     return the raw data values
+  -p iniFile    process the ctd data, requires and addition ini file
+  -o destDir    location to save output files
+  -w [destDir]  build web viewer, optionally specify the destination directory
+                for the webviewer files
 
 Dependency requirements:
 python3
@@ -19,4 +22,4 @@ numpy
 scipy
 gsw
 
-07 Nov 2016
+08 Nov 2016

--- a/converter_scaffolding.py
+++ b/converter_scaffolding.py
@@ -475,77 +475,24 @@ def cnv_handler_1(raw_df, rawConfig, debug=False):
     rare_df.index.name = 'index'
     return rare_df
 
-    '''
-    ### Create a single unified object with all data in there
-    header_string = []
-    header_1 = ''
-    header_2 = ''
-    header_3 = ''
+def importConvertedData(fileName):
+    output_df = pd.read_csv(fileName, index_col=0, parse_dates=False)
+    header_raw = output_df.columns.values.tolist()
+    header_type = [header.split('_')[-1] for header in header_raw]
 
-    """Start writing a .csv file with extension .converted
+    for i, x in enumerate(header_type):
+        debugPrint('Set', header_raw[i], 'to', header_type[i])
+        if header_type[i] == 'bool':
+            d = {'True': True, 'False': False}
+            output_df[header_raw[i]].map(d)
 
-    First part - compose the header.
-    """
+        elif header_type[i] == 'datetime':
+            output_df[header_raw[i]] = output_df[header_raw[i]].astype('datetime64')
 
-    output = ''
+        elif header_type[i] != 'index':
+            output_df[header_raw[i]] = output_df[header_raw[i]].astype('float64')
 
-    debugPrint('Compiling header information')
-    data_list_of_lists = []
-    for x in processed_data:
-        header_string.append(x['sensor_id'])
-        data_list_of_lists.append(x['sci_data'])
-        try:
-            header_1 = header_1 + '{0}{1},'.format(short_lookup[x['sensor_id']]['short_name'], x['channel_pos'])
-        except:
-            header_1 = header_1 + 'error,'
-            errPrint('Error in lookup table: channel_pos for sensor ID:', x['sensor_id'])
-
-        try:
-            header_2 = header_2 + '{0},'.format(short_lookup[x['sensor_id']]['units'])
-        except:
-            header_2 = header_2 + 'error,'
-            errPrint('Error in lookup table: units for sensor ID:', x['sensor_id'])
-
-        try:
-            header_3 = header_3 + '{0},'.format(short_lookup[x['sensor_id']]['type'])
-        except:
-            header_3 = header_3 + 'error,'
-            errPrint('Error in lookup table: type for sensor ID:', x['sensor_id'])
+    return output_df
 
 
-    ##### ------------HACKY DATETIME INSERTION------------ #####
-    #assumes date/time will always be at end, and adds header accordingly
-    #should be rewritten to have cleaner integration with rest of code
-    #header_1 = header_1 + 'lat,lon,new_pos,nmea_time,scan_time'
-    #header_2 = header_2 + 'dec_deg,dec_deg,boolean,ISO8601,ISO8601'
-    #header_3 = header_3 + 'float64,float64,bool_,string,string'
 
-    ### pos/time/date block
-    #data_list_of_lists.append(sbe_reader.parsed_scans[:,(sbe_reader.parsed_scans.shape[1]-1)])
-    ##### ----------HACKY DATETIME INSERTION END---------- #####
-
-    debugPrint('Transposing data')
-    transposed_data = zip(*data_list_of_lists)
-
-    """Write header and body of .csv"""
-
-#    with open(namesplit, 'w') as f:
-#    with open(outputFile, 'w') as f:
-#        f.write(header_1.rstrip(',') + '\n')
-#        f.write(header_2.rstrip(',') + '\n')
-#        f.write(header_3.rstrip(',') + '\n')
-#        for x in transposed_data:
-#            f.write(','.join([str(y) for y in x]) + '\n')
-
-#    with open(namesplit, 'w') as f:
-#    with open(outputFile, 'w') as f:
-    output += header_1.rstrip(',') + '\n'
-    output += header_2.rstrip(',') + '\n'
-    output += header_3.rstrip(',') + '\n'
-    for x in transposed_data:
-        output += ','.join([str(y) for y in x]) + '\n'
-
-#    print('Done, output saved to:', outputFile)
-    debugPrint('Processing complete')
-    return output
-'''

--- a/converter_scaffolding.py
+++ b/converter_scaffolding.py
@@ -3,11 +3,28 @@ import struct
 import sys
 import os
 import json
+import pandas as pd
 
 import sbe_reader as sbe_rd
 import sbe_equations_dict as sbe_eq
 
 DEBUG = False
+
+#lookup table for sensor data
+###DOUBLE CHECK TYPE IS CORRECT###
+short_lookup = {
+    '55':{'short_name': 't', 'long_name':'SBE 3+ Temperature', 'units': 'C', 'type': 'float64'},
+    '45':{'short_name': 'p', 'long_name':'SBE 9+ Pressure', 'units': 'dbar', 'type': 'float64'},
+    '3':{'short_name': 'c', 'long_name':'SBE 4 Conductivity', 'units': 'S/m', 'type':'float64'},
+    '38':{'short_name': 'o', 'long_name':'SBE 43 Oxygen', 'units': 'ml/l', 'type':'float64'},
+    '11':{'short_name': 'fluoro', 'long_name':'Seapoint Fluorometer', 'units': 'ug/l', 'type':'float64'},
+    '27':{'short_name': 'empty', 'long_name':'empty', 'units':'NA', 'type':'NA'},
+    '0':{'short_name': 'alti', 'long_name':'Altitude', 'units':'m', 'type':'float64'},
+    '71':{'short_name': 'cstar', 'long_name':'CStar', 'units': 'ug/l', 'type':'float64'},
+    '61':{'short_name': 'u_def', 'long_name':'user defined', 'units':'V', 'type':'float64'},
+    '1000':{'short_name': 'sal', 'long_name':'Salinity (C1 T1)', 'units':'PSU', 'type':'float64'}
+}
+
 
 def debugPrint(*args, **kwargs):
     if DEBUG:
@@ -88,8 +105,8 @@ def cnv_handler_2(hex_file, xmlcon_file, debug=False):
     debugPrint('Reading/Parsing input files...')
     sbe_reader = sbe_rd.SBEReader.from_paths(hex_file, xmlcon_file)
 
-    debugPrint('Retrieving sensor info from xmlcon file...')
-    sensor_info = sbe_xml_reader_a(xmlcon_file)
+    #debugPrint('Retrieving sensor info from xmlcon file...')
+    #sensor_info = sbe_xml_reader_a(xmlcon_file)
     #debugPrint('Sensor Info:', json.dumps(sensor_info, indent=2))
 
     #namesplit = xmlcon_file.split('.')
@@ -117,21 +134,6 @@ def cnv_handler_2(hex_file, xmlcon_file, debug=False):
     c_array = []
     k_array = []
 
-    #lookup table for sensor data
-    ###DOUBLE CHECK TYPE IS CORRECT###
-    short_lookup = {
-        '55':{'short_name': 't', 'long_name':'SBE 3+ Temperature', 'units': 'C', 'type': 'float64'},
-        '45':{'short_name': 'p', 'long_name':'SBE 9+ Pressure', 'units': 'dbar', 'type': 'float64'},
-        '3':{'short_name': 'c', 'long_name':'SBE 4 Conductivity', 'units': 'S/m', 'type':'float64'},
-        '38':{'short_name': 'o', 'long_name':'SBE 43 Oxygen', 'units': 'ml/l', 'type':'float64'},
-        '11':{'short_name': 'fluoro', 'long_name':'Seapoint Fluorometer', 'units': 'ug/l', 'type':'float64'},
-        '27':{'short_name': 'empty', 'long_name':'empty', 'units':'NA', 'type':'NA'},
-        '0':{'short_name': 'alti', 'long_name':'Altitude', 'units':'m', 'type':'float64'},
-        '71':{'short_name': 'cstar', 'long_name':'CStar', 'units': 'ug/l', 'type':'float64'},
-        '61':{'short_name': 'u_def', 'long_name':'user defined', 'units':'V', 'type':'float64'},
-        '1000':{'short_name': 'sal', 'long_name':'Salinity (C1 T1)', 'units':'PSU', 'type':'float64'}
-    }
-
     ######
     # The following are definitions for every key in the dict below:
     #
@@ -143,32 +145,32 @@ def cnv_handler_2(hex_file, xmlcon_file, debug=False):
     # sensor_info = xml sensor info to convert from eng units to sci units
     ######
 
-    for i, x in enumerate(sensor_info):
+    for i, x in enumerate(sbe_reader.parsed_config):
         #print(i, sensor_dictionary[str(i)]['SensorID'])
-        sensor_id = sensor_info[str(i)]['SensorID']
+        sensor_id = sbe_reader.parsed_config[str(i)]['SensorID']
 
         #temp block
         if str(sensor_id) == '55':
             temp_counter += 1
-            queue_metadata.append({'sensor_id': '55', 'list_id': i, 'channel_pos': temp_counter, 'ranking': 1, 'data': sbe_reader.parsed_scans[:,i], 'sensor_info':sensor_info[str(i)] })
+            queue_metadata.append({'sensor_id': '55', 'list_id': i, 'channel_pos': temp_counter, 'ranking': 1, 'data': sbe_reader.parsed_scans[:,i], 'sensor_info':sbe_reader.parsed_config[str(i)] })
 
         #cond block
         elif str(sensor_id) == '3':
             cond_counter += 1
-            queue_metadata.append({'sensor_id': '3', 'list_id': i, 'channel_pos': cond_counter, 'ranking': 3, 'data': sbe_reader.parsed_scans[:,i], 'sensor_info':sensor_info[str(i)]})
+            queue_metadata.append({'sensor_id': '3', 'list_id': i, 'channel_pos': cond_counter, 'ranking': 3, 'data': sbe_reader.parsed_scans[:,i], 'sensor_info':sbe_reader.parsed_config[str(i)]})
 
         #pressure block
         elif str(sensor_id) == '45':
-            queue_metadata.append({'sensor_id': '45', 'list_id': i, 'channel_pos': '', 'ranking': 2, 'data': sbe_reader.parsed_scans[:,i], 'sensor_info':sensor_info[str(i)]})
+            queue_metadata.append({'sensor_id': '45', 'list_id': i, 'channel_pos': '', 'ranking': 2, 'data': sbe_reader.parsed_scans[:,i], 'sensor_info':sbe_reader.parsed_config[str(i)]})
 
         #oxygen block
         elif str(sensor_id) == '38':
             oxygen_counter += 1
-            queue_metadata.append({'sensor_id': '38', 'list_id': i, 'channel_pos': oxygen_counter, 'ranking': 5, 'data': sbe_reader.parsed_scans[:,i], 'sensor_info':sensor_info[str(i)]})
+            queue_metadata.append({'sensor_id': '38', 'list_id': i, 'channel_pos': oxygen_counter, 'ranking': 5, 'data': sbe_reader.parsed_scans[:,i], 'sensor_info':sbe_reader.parsed_config[str(i)]})
 
         #aux block
         else:
-            queue_metadata.append({'sensor_id': sensor_id, 'list_id': i, 'channel_pos': '', 'ranking': 6, 'data': sbe_reader.parsed_scans[:,i], 'sensor_info':sensor_info[str(i)]})
+            queue_metadata.append({'sensor_id': sensor_id, 'list_id': i, 'channel_pos': '', 'ranking': 6, 'data': sbe_reader.parsed_scans[:,i], 'sensor_info':sbe_reader.parsed_config[str(i)]})
 
     #a temporary block in order to append basic salinity (t1, c1) to file. If additional salinity is needed (different combinations), it'll need a full reworking
     queue_metadata.append({'sensor_id': '1000', 'list_id': 1000, 'channel_pos':'', 'ranking': 4, 'data': '', 'sensor_info':''})
@@ -310,3 +312,228 @@ def cnv_handler_2(hex_file, xmlcon_file, debug=False):
 #    print('Done, output saved to:', outputFile)
     debugPrint('Processing complete')
     return output
+
+def cnv_handler_1(raw_df, rawConfig, debug=False):
+    """Handler to deal with converting eng. data to sci units automatically.
+    When not given a format file/json, default to putting out data in order of instruments in xmlcon.
+    Format file makes assumptions: duplicate sensors are ranked by channel they use, with lower value more important.
+    Ex: For two SBE 3, the temp. sensor on freq. channel 1 is primary temp, and temp. sensor on channel 4 is secondary.
+
+    After reading in format/XMLCON, determine order to put out data.
+    Read sensor dictionary, pull out SensorID number, then match with correct method.
+
+    Read in
+
+    VALUES HARDCODED, TRY TO SETUP A DICT TO MAKE NEATER
+
+    """
+
+    global DEBUG
+    DEBUG = debug
+
+    #needs to search sensor dictionary, and compute in order:
+    #temp, pressure, cond, salinity, oxygen, all aux.
+    #run one loop that builds a queue to determine order of processing, must track which column to pull
+    #process queue, store results in seperate arrays for reuse later
+    #once queue is empty, attach results together according to format order or xmlcon order - structure to keep track
+    queue_metadata = []
+    results = {}
+    temp_counter = 0
+    cond_counter = 0
+    oxygen_counter = 0
+    processed_data = []
+
+    #Temporary arrays to hold sci_data in order to compute following sci_data (pressure, cond, temp, etc)
+    t_array = []
+    p_array = []
+    c_array = []
+    k_array = []
+
+    ######
+    # The following are definitions for every key in the dict below:
+    #
+    # sensor_id = number assigned by SBE for identification in XML
+    # list_id = place in XML array by SBE for determining which sensor is which, alternatively channel number (freq+volt)
+    # channel_pos = is it the first, second, third, etc sensor of its type in the data file, aux sensors default to 0
+    # ranking = data processing ranking - temp first, then pressure, then conductivity, then oxygen, then aux
+    # data = eng units to be converted to sci units
+    # sensor_info = xml sensor info to convert from eng units to sci units
+    ######
+
+    for i, x in enumerate(rawConfig['Sensors']):
+        #print(i)
+        #print(rawConfig['Sensors'][i])
+        sensor_id = rawConfig['Sensors'][i]['SensorID']
+
+        #temp block
+        if sensor_id == '55':
+            temp_counter += 1
+            queue_metadata.append({'sensor_id': '55', 'list_id': i, 'channel_pos': temp_counter, 'ranking': 1, 'column': i, 'sensor_info':rawConfig['Sensors'][i]})
+
+        #cond block
+        elif str(sensor_id) == '3':
+            cond_counter += 1
+            queue_metadata.append({'sensor_id': '3', 'list_id': i, 'channel_pos': cond_counter, 'ranking': 3, 'column': i, 'sensor_info':rawConfig['Sensors'][i]})
+
+        #pressure block
+        elif str(sensor_id) == '45':
+            queue_metadata.append({'sensor_id': '45', 'list_id': i, 'channel_pos': '', 'ranking': 2, 'column': i, 'sensor_info':rawConfig['Sensors'][i]})
+
+        #oxygen block
+        elif str(sensor_id) == '38':
+            oxygen_counter += 1
+            queue_metadata.append({'sensor_id': '38', 'list_id': i, 'channel_pos': oxygen_counter, 'ranking': 5, 'column': i, 'sensor_info':rawConfig['Sensors'][i]})
+
+        #aux block
+        else:
+            queue_metadata.append({'sensor_id': sensor_id, 'list_id': i, 'channel_pos': '', 'ranking': 6, 'column': i, 'sensor_info':rawConfig['Sensors'][i]})
+
+    #a temporary block in order to append basic salinity (t1, c1) to file. If additional salinity is needed (different combinations), it'll need a full reworking
+    queue_metadata.append({'sensor_id': '1000', 'list_id': 1000, 'channel_pos':'', 'ranking': 4, 'column': '', 'sensor_info':''})
+
+    queue_metadata = sorted(queue_metadata, key = lambda sensor: sensor['ranking'])
+    #debugPrint("Queue Metadata:", json.dumps(queue_metadata, indent = 2))
+
+    #queue sorting forces it to be in order, so we don't worry about order here
+    #assumes first channel for each sensor is primary for computing following data, rework to accept file to determine which is primary
+
+    proc_df = pd.DataFrame()
+
+#    debugPrint(raw_df.head())
+
+    for temp_meta in queue_metadata:
+#        print(temp_meta)
+#    while queue_metadata:
+#        temp_meta = queue_metadata.pop(0)
+
+        column_name = '{0}{1}_{2}'.format(short_lookup[temp_meta['sensor_id']]['short_name'], temp_meta['channel_pos'], short_lookup[temp_meta['sensor_id']]['units'])
+
+        ###Temperature block
+        if temp_meta['sensor_id'] == '55':
+            debugPrint('Processing Sensor ID:', temp_meta['sensor_id'] + ',', short_lookup[temp_meta['sensor_id']]['long_name'])
+            proc_df[column_name] = sbe_eq.temp_its90_dict(temp_meta['sensor_info'], raw_df[temp_meta['column']])
+            if temp_meta['list_id'] == 0:
+                t_array = proc_df[column_name].astype(type('float', (float,), {}))
+                k_array = [273.15+celcius for celcius in t_array]
+                debugPrint('\tPrimary temperature used:', t_array[0], short_lookup[temp_meta['sensor_id']]['units'])
+            #processed_data.append(temp_meta)
+
+        ### Pressure block
+        elif temp_meta['sensor_id'] == '45':
+            debugPrint('Processing Sensor ID:', temp_meta['sensor_id'] + ',', short_lookup[temp_meta['sensor_id']]['long_name'])
+            proc_df[column_name] = sbe_eq.pressure_dict(temp_meta['sensor_info'], raw_df[temp_meta['column']], t_array)
+            if temp_meta['list_id'] == 2:
+                p_array = proc_df[column_name].astype(type('float', (float,), {}))
+                debugPrint('\tPressure used:', p_array[0], short_lookup[temp_meta['sensor_id']]['units'])
+            #processed_data.append(temp_meta)
+
+        ### Conductivity block
+        elif temp_meta['sensor_id'] == '3':
+            debugPrint('Processing Sensor ID:', temp_meta['sensor_id'] + ',', short_lookup[temp_meta['sensor_id']]['long_name'])
+            proc_df[column_name] = sbe_eq.cond_dict(temp_meta['sensor_info'], raw_df[temp_meta['column']], t_array, p_array)
+            if temp_meta['list_id'] == 1:
+                c_array = proc_df[column_name].astype(type('float', (float,), {}))
+                debugPrint('\tPrimary cond used:', c_array[0], short_lookup[temp_meta['sensor_id']]['units'])
+            #processed_data.append(temp_meta)
+
+        ### Oxygen block
+        elif temp_meta['sensor_id'] == '38':
+            debugPrint('Processing Sensor ID:', temp_meta['sensor_id'] + ',', short_lookup[temp_meta['sensor_id']]['long_name'])
+            proc_df[column_name] = sbe_eq.oxy_dict(temp_meta['sensor_info'], p_array, k_array, t_array, c_array, raw_df[temp_meta['column']])
+            #processed_data.append(temp_meta)
+
+        ### Fluorometer Seapoint block
+        elif temp_meta['sensor_id'] == '11':
+            debugPrint('Processing Sensor ID:', temp_meta['sensor_id'] + ',', short_lookup[temp_meta['sensor_id']]['long_name'])
+            proc_df[column_name] = sbe_eq.fluoro_seapoint_dict(temp_meta['sensor_info'], raw_df[temp_meta['column']])
+            #processed_data.append(temp_meta)
+
+        ###Salinity block
+        elif temp_meta['sensor_id'] == '1000':
+            debugPrint('Processing Sensor ID:', temp_meta['sensor_id'] + ',', short_lookup[temp_meta['sensor_id']]['long_name'])
+            proc_df[column_name] = sbe_eq.sp_dict(c_array, t_array, p_array)
+            #processed_data.append(temp_meta)
+
+        ### Aux block
+        else:
+            debugPrint('Skipping Sensor ID:', temp_meta['sensor_id'] + ',', short_lookup[temp_meta['sensor_id']]['long_name'])
+            proc_df[column_name] = raw_df[temp_meta['column']]
+            #processed_data.append(temp_meta)
+
+    proc_df.index.name = 'index'
+    return proc_df
+
+    '''
+    ### Create a single unified object with all data in there
+    header_string = []
+    header_1 = ''
+    header_2 = ''
+    header_3 = ''
+
+    """Start writing a .csv file with extension .converted
+
+    First part - compose the header.
+    """
+
+    output = ''
+
+    debugPrint('Compiling header information')
+    data_list_of_lists = []
+    for x in processed_data:
+        header_string.append(x['sensor_id'])
+        data_list_of_lists.append(x['sci_data'])
+        try:
+            header_1 = header_1 + '{0}{1},'.format(short_lookup[x['sensor_id']]['short_name'], x['channel_pos'])
+        except:
+            header_1 = header_1 + 'error,'
+            errPrint('Error in lookup table: channel_pos for sensor ID:', x['sensor_id'])
+
+        try:
+            header_2 = header_2 + '{0},'.format(short_lookup[x['sensor_id']]['units'])
+        except:
+            header_2 = header_2 + 'error,'
+            errPrint('Error in lookup table: units for sensor ID:', x['sensor_id'])
+
+        try:
+            header_3 = header_3 + '{0},'.format(short_lookup[x['sensor_id']]['type'])
+        except:
+            header_3 = header_3 + 'error,'
+            errPrint('Error in lookup table: type for sensor ID:', x['sensor_id'])
+
+
+    ##### ------------HACKY DATETIME INSERTION------------ #####
+    #assumes date/time will always be at end, and adds header accordingly
+    #should be rewritten to have cleaner integration with rest of code
+    #header_1 = header_1 + 'lat,lon,new_pos,nmea_time,scan_time'
+    #header_2 = header_2 + 'dec_deg,dec_deg,boolean,ISO8601,ISO8601'
+    #header_3 = header_3 + 'float64,float64,bool_,string,string'
+
+    ### pos/time/date block
+    #data_list_of_lists.append(sbe_reader.parsed_scans[:,(sbe_reader.parsed_scans.shape[1]-1)])
+    ##### ----------HACKY DATETIME INSERTION END---------- #####
+
+    debugPrint('Transposing data')
+    transposed_data = zip(*data_list_of_lists)
+
+    """Write header and body of .csv"""
+
+#    with open(namesplit, 'w') as f:
+#    with open(outputFile, 'w') as f:
+#        f.write(header_1.rstrip(',') + '\n')
+#        f.write(header_2.rstrip(',') + '\n')
+#        f.write(header_3.rstrip(',') + '\n')
+#        for x in transposed_data:
+#            f.write(','.join([str(y) for y in x]) + '\n')
+
+#    with open(namesplit, 'w') as f:
+#    with open(outputFile, 'w') as f:
+    output += header_1.rstrip(',') + '\n'
+    output += header_2.rstrip(',') + '\n'
+    output += header_3.rstrip(',') + '\n'
+    for x in transposed_data:
+        output += ','.join([str(y) for y in x]) + '\n'
+
+#    print('Done, output saved to:', outputFile)
+    debugPrint('Processing complete')
+    return output
+'''

--- a/run.py
+++ b/run.py
@@ -1,10 +1,29 @@
 import sys
 import os
 import argparse
+import sbe_reader
+import json
+import numpy as np
+import pandas as pd
+import web_viewer as wv
 import converter_scaffolding as cnv
-import converter
+#import converter
+#import raw_converter
 
 DEBUG = False
+
+#File extension to use for output files (csv-formatted)
+FILE_EXT = 'csv'
+
+#File extension to use for raw output
+RAW_SUFFIX = '_raw'
+
+#File extension to use for converted output
+RARE_SUFFIX = '_converted'
+
+#File extension to use for processed output
+PROC_SUFFIX = '_proc'
+
 
 def debugPrint(*args, **kwargs):
     if DEBUG:
@@ -17,58 +36,176 @@ def errPrint(*args, **kwargs):
 # Main function of the script should it be run as a stand-alone utility.
 # -------------------------------------------------------------------------------------
 def main(argv):
-'''
-    parser = argparse.ArgumentParser(description='Convert SBE CTD data into engineering units')
+
+    parser = argparse.ArgumentParser(description='General Utility for processing SBE Data')
     parser.add_argument('hexFile', metavar='hex File', help='the .hex data file to process')
     parser.add_argument('xmlconFile', metavar='XMLCON File', help='the .XMLCON data file to process')
-    parser.add_argument('-o', metavar='output file', dest='outFile', help='name and location of output file')
-    parser.add_argument('-d', '--debug', action='store_true', help='display debug messages')
-    parser.add_argument('-w', metavar='dest dir', dest='wvDir', nargs='?', const='default', help='build web viewer, optionally specify the destination directory for the webviewer files')
 
+    # debug messages
+    parser.add_argument('-d', '--debug', action='store_true', help='display debug messages')
+
+    # raw output
+    parser.add_argument('-r', '--raw', action='store_true', help='return the raw data values')
+
+    # processed output
+    parser.add_argument('-p', metavar='iniFile', dest='iniFile', help='process the ctd data, requires and addition ini file')
+
+    # output directory
+    parser.add_argument('-o', metavar='destDir', dest='outDir', help='location to save output files')
+
+    # web viewer
+    parser.add_argument('-w', metavar='destDir', dest='wvDir', nargs='?', const='default', help='build web viewer, optionally specify the destination directory for the webviewer files')
+
+    # Process Command-line args
     args = parser.parse_args()
     if args.debug:
         global DEBUG
         DEBUG = True
         debugPrint("Running in debug mode")
 
+    # Verify hex file exists
     if not os.path.isfile(args.hexFile):
         errPrint('ERROR: Input hex file:', args.hexFile, 'not found\n')
         sys.exit(1)
 
+    # Verify xmlcon file exists
     if not os.path.isfile(args.xmlconFile):
         errPrint('ERROR: Input xmlcon file:', args.xmlconFile, 'not found\n')
         sys.exit(1)
 
-    if args.outFile:
-        if os.path.isdir(os.path.dirname(args.outFile)):
-            outputFile = args.outFile
-        else:
-            errPrint('ERROR: Unable to save output to:', args.outFile, '  Destination is unreachable.\n')
+    # Verify ini file exists
+    if args.iniFile:
+        if not os.path.isfile(args.iniFile):
+            errPrint('ERROR: Input ini file:', args.iniFile, 'not found\n')
             sys.exit(1)
-    else:
-        outputFile = os.path.splitext(args.xmlconFile)[0] + '.converted'
 
-    output = cnv.cnv_handler_2(args.hexFile, args.xmlconFile, DEBUG)
 
-    if output == None:
-        errPrint('No data returned from converter')
-    else:
-        debugPrint('Saving output to:', outputFile)
-        with open(outputFile, 'w') as f:
-            f.write(output)
+    # Set the default output directory to be the same directory as the hex file
+    outputDir = os.path.dirname(args.hexFile)
 
-DEBUG = False
+    # Used later for building output file names
+    filename_ext = os.path.basename(args.hexFile) # original filename with ext
+    filename_base = os.path.splitext(filename_ext)[0] # original filename w/o ext
 
-def debugPrint(*args, **kwargs):
-    if DEBUG:
-        errPrint(*args, **kwargs)
+    # Verify Output Directory exists
+    if args.outDir:
+        if os.path.isdir(args.outDir):
+            outputDir = args.outDir
+        else:
+            errPrint('ERROR: Output directory:', args.outDir, 'is unreachable.\n')
+            sys.exit(1)
 
-def errPrint(*args, **kwargs):
-    print(*args, file=sys.stderr, **kwargs)
-'''
-    converter.main(hexFile,xmlconFile,DEBUG)
+    # Parse the input files
+    debugPrint("Parsing", args.hexFile, "and", args.xmlconFile)
+    sbeReader = sbe_reader.SBEReader.from_paths(args.hexFile, args.xmlconFile)
+
+    # Retrieve parsed scans
+    rawData = sbeReader.parsed_scans()
+
+    # Convert raw data to dataframe
+    raw_df = pd.DataFrame(rawData)
+    raw_df.index.name = 'index'
+    raw_df = raw_df.apply(pd.to_numeric, errors="ignore")
+    #debugPrint("Raw Data Types:", raw_df.dtypes)
+    #debugPrint("Raw Data:", raw_df.head)
+
+    # Retrieve Config data
+    rawConfig = sbeReader.parsed_config()
+    #debugPrint("Raw Config:", json.dumps(rawConfig, indent=2))
+
+    # Save the raw scans as csv
+    if args.raw:
+        rawfileName = str(filename_base + RAW_SUFFIX + '.' + FILE_EXT)
+        rawfilePath = os.path.join(outputDir, rawfileName)
+
+        debugPrint('Saving raw data to:', rawfilePath)
+        try:
+            raw_df.to_csv(rawfilePath)
+        except:
+            errPrint('ERROR: Could not save raw data to:', rawfilePath)
+
+    #Show the following sensor configuration data
+    #sensorID = 5
+    #debugPrint("Sensor #" + sensorID + ":", rawConfig['Sensors'][sensorID])
+
+    debugPrint("Converting raw scans to scientific units")
+    rare_df = cnv.cnv_handler_1(raw_df, rawConfig, DEBUG)
+
+    #debugPrint('rare_df:', rare_df.head())
+
+    rarefileName  = filename_base + RARE_SUFFIX + '.' + FILE_EXT
+    rarefilePath = os.path.join(outputDir, rarefileName)
+
+    debugPrint('Saving rare data to:', rarefilePath)
+    try:
+        rare_df.to_csv(rarefilePath)
+    except:
+        errPrint('ERROR: Could not save rare data to:', rarefilePath)
+
+
+    if args.iniFile:
+        # Verify xmlcon file exists
+        if not os.path.isfile(args.iniFile):
+            errPrint('ERROR: Input ini file:', args.iniFile, 'not found\n\tSkipping processing')
+        else:
+            debugPrint('Processing data')
+            # ---------------------------------------------------------------- #
+            #
+            #  Here's where you can make a call to any CTD processing classes
+            #  of functions.
+            #  
+            #  The raw scans are available at: raw_df, (pandas dataframe)
+            #  The sensor config is available as: rawConfig, (object) 
+            #  The cooked data is available at: rare_df, (pandas dataframe)
+            #  The ini file needed for processing is available at: args.iniFile
+            #
+            # -----------------------------------------------------------------#
+
+    if args.wvDir:
+        debugPrint('Building webviewer')
+        webView = wv.WebViewer()
+        if DEBUG:
+            webView._setDebug()
+
+        debugPrint('\tSetting webviewer directory to: ', end='')
+        if args.wvDir == 'default':
+            wvDir = os.path.join(os.path.dirname(args.hexFile),'webviewer')
+            debugPrint(wvDir + '... ', end='')
+        else:
+            wvDir = args.wvDir
+            debugPrint(wvDir + '... ', end='')
+
+        try:
+            os.mkdir(wvDir, 0o755);
+        except FileExistsError as exception:
+            pass
+        except PermissionError as exception:
+            errPrint('ERROR: do not have write permission at destination directory')
+            sys.exit(1)
+
+        debugPrint('Success!')
+
+        webView._setWebviewerFolder(wvDir)
+
+        debugPrint('\tCreating webviewer directory structure... ', end='')
+
+        if webView._buildScaffolding():
+            debugPrint('Success!')
+        else:
+            debugPrint('ERROR!')
+            errPrint('Unable to created webviewer directories')
+            sys.exit(1)
+
+        debugPrint("Building data file for webviewer... ", end='')
+        output = webView._buildDataFromDF(rare_df, args.hexFile)
+        debugPrint('Success!')
+
+        debugPrint('Saving webviewer data to file... ', end='')
+        webView._saveData(output)
+        debugPrint('Success!')
+
 # -------------------------------------------------------------------------------------
 # Required python code for running the script as a stand-alone utility
 # -------------------------------------------------------------------------------------
 if __name__ == '__main__':
-	main(sys.argv[1:])
+    main(sys.argv[1:])

--- a/run.py
+++ b/run.py
@@ -2,8 +2,6 @@ import sys
 import os
 import argparse
 import sbe_reader
-import json
-import numpy as np
 import pandas as pd
 import web_viewer as wv
 import converter_scaffolding as cnv
@@ -19,7 +17,7 @@ FILE_EXT = 'csv'
 RAW_SUFFIX = '_raw'
 
 #File extension to use for converted output
-RARE_SUFFIX = '_converted'
+CONVERTED_SUFFIX = '_converted'
 
 #File extension to use for processed output
 PROC_SUFFIX = '_proc'
@@ -96,77 +94,58 @@ def main(argv):
             sys.exit(1)
 
     # Parse the input files
-    debugPrint("Parsing", args.hexFile, "and", args.xmlconFile)
+    debugPrint("Parsing", args.hexFile, "and", args.xmlconFile + '... ', end='')
     sbeReader = sbe_reader.SBEReader.from_paths(args.hexFile, args.xmlconFile)
-
-    # Retrieve parsed scans
-    rawData = sbeReader.parsed_scans()
-
-    # Convert raw data to dataframe
-    raw_df = pd.DataFrame(rawData)
-    raw_df.index.name = 'index'
-    raw_df = raw_df.apply(pd.to_numeric, errors="ignore")
-
-    #debugPrint("Raw Data Types:", raw_df.dtypes)
-    #debugPrint("Raw Data:", raw_df.head)
-
-    # Retrieve Config data
-    rawConfig = sbeReader.parsed_config()
-    #debugPrint("Raw Config:", json.dumps(rawConfig, indent=2))
-
-    #Show the following sensor configuration data
-    #sensorID = 5
-    #debugPrint("Sensor #" + sensorID + ":", rawConfig['Sensors'][sensorID])
+    debugPrint("Success!")
 
     # Save the raw scans as csv
     if args.raw:
+
+        debugPrint('Building raw dataset... ', end='')
+
+        # Retrieve parsed scans
+        rawData = sbeReader.parsed_scans()
+
+        # Convert raw data to dataframe
+        raw_df = pd.DataFrame(rawData)
+        raw_df.index.name = 'index'
+        raw_df = raw_df.apply(pd.to_numeric, errors="ignore")
+
+        debugPrint('Success!')
+
+        #debugPrint("Raw Data Types:", raw_df.dtypes)
+        #debugPrint("Raw Data:", raw_df.head)
+
+        # Retrieve Config data
+        #rawConfig = sbeReader.parsed_config()
+
         rawfileName = str(filename_base + RAW_SUFFIX + '.' + FILE_EXT)
         rawfilePath = os.path.join(outputDir, rawfileName)
 
-        debugPrint('Saving raw data to:', rawfilePath)
+        debugPrint('Saving raw data to:', rawfilePath + '... ', end='')
         try:
             raw_df.to_csv(rawfilePath)
         except:
-            errPrint('ERROR: Could not save raw data to:', rawfilePath)
-
-
-    debugPrint("Building meta data dataframe")
-    metaArray = [line.split(',') for line in sbeReader._parse_scans_meta().tolist()]
-    metaArrayheaders = sbeReader._breakdown_header()
-    meta_df = pd.DataFrame(metaArray)
-
-    meta_df.columns = metaArrayheaders[0]
-    meta_df.index.name = 'index'
-
-    for i, x in enumerate(metaArrayheaders[0]):
-        #debugPrint('Set', metaArrayheaders[0][i], 'to', metaArrayheaders[1][i])
-        if not metaArrayheaders[1][i] == 'bool_':
-            meta_df[metaArrayheaders[0][i]] = meta_df[metaArrayheaders[0][i]].astype(metaArrayheaders[1][i])
+            errPrint('ERROR: Could not save raw data to file')
         else:
-            d = {'True': True, 'False': False}
-            meta_df[metaArrayheaders[0][i]].map(d)
-
-    #debugPrint("Meta Data Types:\n", meta_df.dtypes)
-    #debugPrint("Meta Data Types:\n", meta_df.head())
+            debugPrint('Success!')
     
-    debugPrint("Converting raw scans to scientific units")
-    rare_df = cnv.cnv_handler_1(raw_df, rawConfig, DEBUG)
 
-    #debugPrint('rare_df:', rare_df.head())
+    debugPrint("Converting raw scans to scientific units... ")
+    converted_df = cnv.convertFromSBEReader(sbeReader, DEBUG)
 
-    debugPrint("Joining with meta array")
-    rare_df = rare_df.join(meta_df)
+    #debugPrint('converted_df:\n', converted_df.head())    
 
-    #debugPrint('rare_df:', rare_df.head())    
+    convertedfileName  = filename_base + CONVERTED_SUFFIX + '.' + FILE_EXT
+    convertedfilePath = os.path.join(outputDir, convertedfileName)
 
-    rarefileName  = filename_base + RARE_SUFFIX + '.' + FILE_EXT
-    rarefilePath = os.path.join(outputDir, rarefileName)
-
-    debugPrint('Saving rare data to:', rarefilePath)
+    debugPrint('Saving converted data to:', convertedfilePath + '... ', end='')
     try:
-        rare_df.to_csv(rarefilePath)
+        converted_df.to_csv(convertedfilePath)
     except:
-        errPrint('ERROR: Could not save rare data to:', rarefilePath)
+        errPrint('ERROR: Could not save converted data to file')
+    else:
+        debugPrint('Success!')
 
 
     if args.iniFile:
@@ -182,7 +161,7 @@ def main(argv):
             #  
             #  The raw scans are available at: raw_df, (pandas dataframe)
             #  The sensor config is available as: rawConfig, (object) 
-            #  The cooked data is available at: rare_df, (pandas dataframe)
+            #  The cooked data is available at: converted_df, (pandas dataframe)
             #  The ini file needed for processing is available at: args.iniFile
             #
             # -----------------------------------------------------------------#
@@ -223,12 +202,14 @@ def main(argv):
             sys.exit(1)
 
         debugPrint("Building data file for webviewer... ", end='')
-        output = webView._buildDataFromDF(rare_df, args.hexFile)
+        output = webView._buildDataFromDF(converted_df, args.hexFile)
         debugPrint('Success!')
 
         debugPrint('Saving webviewer data to file... ', end='')
         webView._saveData(output)
         debugPrint('Success!')
+
+    debugPrint('Done!')
 
 # -------------------------------------------------------------------------------------
 # Required python code for running the script as a stand-alone utility

--- a/sampleConvert.py
+++ b/sampleConvert.py
@@ -1,0 +1,55 @@
+import sys
+import os
+import argparse
+import pandas as pd
+import converter_scaffolding as cnv
+
+DEBUG = False
+
+def debugPrint(*args, **kwargs):
+    if DEBUG:
+        errPrint(*args, **kwargs)
+
+def errPrint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+# -------------------------------------------------------------------------------------
+# Main function of the script should it be run as a stand-alone utility.
+# -------------------------------------------------------------------------------------
+def main(argv):
+
+    parser = argparse.ArgumentParser(description='Sample Script for converting raw SBE Data')
+    parser.add_argument('hexFile', metavar='hex File', help='the .hex data file to process')
+    parser.add_argument('xmlconFile', metavar='XMLCON File', help='the .XMLCON data file to process')
+
+    # debug messages
+    parser.add_argument('-d', '--debug', action='store_true', help='display debug messages')
+
+    args = parser.parse_args()
+    if args.debug:
+        global DEBUG
+        DEBUG = True
+        debugPrint("Running in debug mode")
+
+    # Verify hex file exists
+    if not os.path.isfile(args.hexFile):
+        errPrint('ERROR: Input hex file:', args.hexFile, 'not found\n')
+        sys.exit(1)
+
+    # Verify xmlcon file exists
+    if not os.path.isfile(args.xmlconFile):
+        errPrint('ERROR: Input xmlcon file:', args.xmlconFile, 'not found\n')
+        sys.exit(1)
+
+    debugPrint("Converting raw scans to scientific units... ", end='')
+    converted_df = cnv.convertFromFiles(args.hexFile, args.xmlconFile, DEBUG)
+    debugPrint("Success!")
+
+    errPrint(converted_df.head())
+    errPrint(converted_df.dtypes)
+
+# -------------------------------------------------------------------------------------
+# Required python code for running the script as a stand-alone utility
+# -------------------------------------------------------------------------------------
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/sampleImport.py
+++ b/sampleImport.py
@@ -1,0 +1,49 @@
+import sys
+import os
+import argparse
+import pandas as pd
+import converter_scaffolding as cnv
+
+DEBUG = False
+
+def debugPrint(*args, **kwargs):
+    if DEBUG:
+        errPrint(*args, **kwargs)
+
+def errPrint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+# -------------------------------------------------------------------------------------
+# Main function of the script should it be run as a stand-alone utility.
+# -------------------------------------------------------------------------------------
+def main(argv):
+
+    parser = argparse.ArgumentParser(description='Sample Script for importing converted SBE Data')
+    parser.add_argument('convertedFile', metavar='converted File', help='the converted data file to process')
+
+    # debug messages
+    parser.add_argument('-d', '--debug', action='store_true', help='display debug messages')
+
+    args = parser.parse_args()
+    if args.debug:
+        global DEBUG
+        DEBUG = True
+        debugPrint("Running in debug mode")
+
+    # Verify hex file exists
+    if not os.path.isfile(args.convertedFile):
+        errPrint('ERROR: Input converted file:', args.convertedFile, 'not found\n')
+        sys.exit(1)
+
+    debugPrint("Import converted data to dataframe... ", end='')
+    imported_df = cnv.importConvertedFile(args.convertedFile, DEBUG)
+    debugPrint("Success!")
+
+    errPrint(imported_df.head())
+    errPrint(imported_df.dtypes)
+
+# -------------------------------------------------------------------------------------
+# Required python code for running the script as a stand-alone utility
+# -------------------------------------------------------------------------------------
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/sbe_equations_dict.py
+++ b/sbe_equations_dict.py
@@ -118,6 +118,7 @@ def oxy_dict(calib, P, K, T, S, V):
     """
 
     """Assumes all are arrays, or none are arrays. Need way to test for them. """
+
     try:
         oxygen = []
         for P_x, K_x, T_x, S_x, V_x in zip(P, K, T, S, V):

--- a/sbe_reader.py
+++ b/sbe_reader.py
@@ -133,9 +133,11 @@ class SBEReader():
         #breaks down line according to columns specified by unpack_str and converts from hex to decimal MSB first
         #needs to be adjusted for LSB fields (NMEA time, scan time), break into two lines? move int(x,16) outside
         measurements = [line for line in struct.iter_unpack(unpack_str, the_bytes)]
-        measurements_2 = np.array([self._breakdown(line) for line in measurements])
-        #print(measurements_2.shape)
+        measurements_2 = np.array([self._breakdown(line) for line in measurements]) 
+        #measurements_2 = [self._breakdown(line) for line in measurements]
+                #print(measurements_2.shape)
 
+#        return measurements
         return measurements_2
 
     '''
@@ -184,9 +186,23 @@ class SBEReader():
         Scan time is LSB, 8 char long, in seconds since January 1, 1970
         '''
         #line[13]
-        output = output + str(self._sbe_time(self._reverse_bytes(line[13]), 'scan'))
+        output = output + str(self._sbe_time(self._reverse_bytes(line[13]), 'scan')) + ','
+
+        '''
+        Bottle fire - should match up exactly, might not.
+        '''
+        output = output + str(self._bottle_fire(line[11]))
 
         return output
+
+    def _breakdown_header(self):
+        output = [
+            ['lat_ddeg', 'lon_ddeg', 'new_fix_bool', 'nmea_datetime', 'scan_datetime', 'btl_fire_bool'],
+            ['float64', 'float64', 'bool_', 'datetime64', 'datetime64', 'bool_']
+        ]
+
+        return output
+
 
     def _location_fix(self, b1, b2, b3, b4, b5, b6, b7):
         """Determine location from SBE format.
@@ -334,7 +350,7 @@ class SBEReader():
 
         mask_bottle_fire = 0x4
 
-        if flag_char & mask_bottle_fire:
+        if int(flag_char, 16) & mask_bottle_fire:
             return(True)
         else:
             return(False)

--- a/web_viewer.py
+++ b/web_viewer.py
@@ -136,6 +136,42 @@ class WebViewer():
 
 		return json.dumps(output)
 
+	def _buildDataFromDF(self, dataframe, castName):
+
+		output = {
+			'castName':castName,
+			'visualizerData':[],
+			'stats':[]
+		}
+
+		total_rows = len(dataframe.index)
+		#debugPrint('total_rows:', total_rows)
+
+		#get name/units
+		headers = dataframe.columns.values.tolist()
+
+		proc_units = []
+		proc_short_name = []
+		for header in headers:
+			header_array = header.split('_')
+			proc_units.append(header_array.pop())
+			proc_short_name.append('_'.join(header_array))
+
+		
+		# The row indices to skip - make sure 0 is not included to keep the header!
+		skip_idx = [x for x in range(3, total_rows) if x % subSampleRate == 0]
+		#debugPrint(skip_idx)
+
+		for idx, val in enumerate(proc_short_name):
+			if proc_short_name != 'index':
+				stat = {'statName': proc_short_name[idx] + ' Bounds','statUnit': proc_units[idx], 'statType':'bounds', 'statData':[round(dataframe.iloc[:,idx].min(),3), round(dataframe.iloc[:,idx].max(),3)]}
+				output['stats'].append(stat)
+
+				data = {'data': dataframe.iloc[skip_idx,idx].tolist(), 'unit':proc_units[idx], 'label':proc_short_name[idx]}
+				output['visualizerData'].append(data)
+
+		return json.dumps(output)
+
 	def _saveData(self, output):
 		dataFilename = 'data.json'
 		dataFilePath = os.path.join(self.parentDir, dataDir, dataFilename)


### PR DESCRIPTION
Ok this was a big one...
I saw a todo list in testing.py where that code needed to be integrated into run.py (or at least called by run.py)  I also saw where testing.py was dealing with a csv but then converting it to a dataframe.  The web_viewer code also builds a dataframe from the csv to due the format translation and collect stats.  All of these hex-->csv-->dataframe-->json conversions are really inefficient so I tweaked everything just work in dataframes. (I didn't touch testing.py).

Now when the raw data is initially parsed its returned as a dataframe (raw_df)
That raw dataframe can be saved as a csv (via the new -r flag) and/or passed to a new version of the cnv handler (cnv_handler_1) which now returns a separate dataframe containing the scientific values (rare_df).

The web_viewer code has been tweaked to take this rare dataframe as it's input.

I've also added a -p flag for specifying an ini file to be used with the processing code.  My hope was that by building a rare_df file and python object with the sensor data (rawConfig) it would simplify the integration process.

Taking this approach of moving directly to dataframes and then passing dataframes around should simplify adding additional steps in the future.

One caveats...
this broke adding time and position to the converted data... will need to look at that tomorrow.  The good news is that by converting straight to a dataframe these columns can be added as meaningful datatypes (datetime). 

I hope this helps.
-W