### PR TITLE
Modification to _converted.csv file header records

### DIFF
--- a/bottleNewStyle.py
+++ b/bottleNewStyle.py
@@ -1,0 +1,100 @@
+import sys
+import os
+import argparse
+import pandas as pd
+import converter_scaffolding as cnv
+import bottle_lib as btl
+
+#File extension to use for output files (csv-formatted)
+FILE_EXT = 'csv'
+
+#File extension to use for converted output
+CONVERTED_SUFFIX = '_converted'
+
+#File extension to use for processed output
+BOTTLE_SUFFIX = '_btl'
+
+DEBUG = False
+
+def debugPrint(*args, **kwargs):
+    if DEBUG:
+        errPrint(*args, **kwargs)
+
+def errPrint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+# -------------------------------------------------------------------------------------
+# Main function of the script should it be run as a stand-alone utility.
+# -------------------------------------------------------------------------------------
+def main(argv):
+
+    parser = argparse.ArgumentParser(description='Build bottle file from converted file')
+    parser.add_argument('convertedFile', metavar='converted File', help='the converted data file to process')
+
+    # debug messages
+    parser.add_argument('-d', '--debug', action='store_true', help='display debug messages')
+
+    # output directory
+    parser.add_argument('-o', metavar='destDir', dest='outDir', help='location to save output files')
+
+    args = parser.parse_args()
+    if args.debug:
+        global DEBUG
+        DEBUG = True
+        debugPrint("Running in debug mode")
+
+    # Verify converted exists
+    if not os.path.isfile(args.convertedFile):
+        errPrint('ERROR: Input converted file:', args.convertedFile, 'not found\n')
+        sys.exit(1)
+
+    # Set the default output directory to be the same directory as the hex file
+    outputDir = os.path.dirname(args.convertedFile)
+
+    # Used later for building output file names
+    filename_ext = os.path.basename(args.convertedFile) # original filename with ext
+    filename_base = os.path.splitext(filename_ext)[0] # original filename w/o ext
+
+    # Verify Output Directory exists
+    if args.outDir:
+        if os.path.isdir(args.outDir):
+            outputDir = args.outDir
+        else:
+            errPrint('ERROR: Output directory:', args.outDir, 'is unreachable.\n')
+            sys.exit(1)
+
+    debugPrint("Import converted data to dataframe... ", end='')
+    imported_df = cnv.importConvertedFile(args.convertedFile, DEBUG)
+    debugPrint("Success!")
+
+    #debugPrint(imported_df.head())
+    #debugPrint(imported_df.dtypes)
+
+    # Retrieve the rows from the imported dataframe where the btl_fire_bool column == True
+    # Returns a new dataframe
+    bottle_df = btl.retrieveBottleData(imported_df, DEBUG)
+
+    if bottle_df.empty:
+        errPrint("Bottle fire data not found in converted file")
+        sys.exit(1)
+    else:
+        debugPrint(bottle_df.head())
+        debugPrint(bottle_df.dtypes)
+
+    # Build the filename for the bottle fire data
+    bottlefileName  = filename_base.replace(CONVERTED_SUFFIX,'') + BOTTLE_SUFFIX + '.' + FILE_EXT
+    bottlefilePath = os.path.join(outputDir, bottlefileName)
+
+    # Save the bottle fire dataframe to file.
+    debugPrint('Saving bottle data to:', bottlefilePath + '... ', end='')
+    if not cnv.saveConvertedDataToFile(bottle_df, bottlefilePath, DEBUG):
+        errPrint('ERROR: Could not save bottle fire data to file')
+    else:
+        debugPrint('Success!')
+
+
+# -------------------------------------------------------------------------------------
+# Required python code for running the script as a stand-alone utility
+# -------------------------------------------------------------------------------------
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/bottleNewStyle.py
+++ b/bottleNewStyle.py
@@ -64,10 +64,10 @@ def main(argv):
             sys.exit(1)
 
     debugPrint("Import converted data to dataframe... ", end='')
-    imported_df = cnv.importConvertedFile(args.convertedFile, DEBUG)
+    imported_df = cnv.importConvertedFile(args.convertedFile, False)
     debugPrint("Success!")
 
-    #debugPrint(imported_df.head())
+    debugPrint(imported_df.head())
     #debugPrint(imported_df.dtypes)
 
     # Retrieve the rows from the imported dataframe where the btl_fire_bool column == True
@@ -78,8 +78,14 @@ def main(argv):
         errPrint("Bottle fire data not found in converted file")
         sys.exit(1)
     else:
-        debugPrint(bottle_df.head())
-        debugPrint(bottle_df.dtypes)
+        total_bottles_fired = bottle_df["bottle_fire_num"].iloc[-1]
+        debugPrint(total_bottles_fired, "bottle fire(s) detected")
+        bottle_num = 1
+
+        while bottle_num <= total_bottles_fired:
+            debugPrint('Bottle:', bottle_num)
+            debugPrint(bottle_df.loc[bottle_df['bottle_fire_num'] == bottle_num].head())
+            bottle_num += 1
 
     # Build the filename for the bottle fire data
     bottlefileName  = filename_base.replace(CONVERTED_SUFFIX,'') + BOTTLE_SUFFIX + '.' + FILE_EXT

--- a/bottle_lib.py
+++ b/bottle_lib.py
@@ -10,6 +10,38 @@ import sys
 import csv
 import datetime
 import statistics
+import converter_scaffolding as cnv
+import pandas as pd
+
+
+BOTTLE_FIRE_COL_NAME = 'btl_fire'
+
+DEBUG = False
+
+def debugPrint(*args, **kwargs):
+    if DEBUG:
+        errPrint(*args, **kwargs)
+
+def errPrint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+# Retrieve the bottle data from a converted file.
+def retrieveBottleDataFromFile(converted_file, debug=False):
+
+    converted_df = cnv.importConvertedFile(converted_file, DEBUG)
+    
+    return retrieveBottleData(converted_df, debug)
+
+
+# Retrieve the bottle data from a dataframe created from a converted file.
+def retrieveBottleData(converted_df, debug=False):
+    if BOTTLE_FIRE_COL_NAME in converted_df.columns:
+        return converted_df.loc[converted_df[BOTTLE_FIRE_COL_NAME] == True]
+    else:
+        debugPrint("Bottle fire column:", BOTTLE_FIRE_COL_NAME, "not found")
+    
+    return pd.DataFrame() #empty dataframe
+
 
 
 def handler(converted_file, config_file=False, debug=False):

--- a/bottle_lib.py
+++ b/bottle_lib.py
@@ -36,7 +36,11 @@ def retrieveBottleDataFromFile(converted_file, debug=False):
 # Retrieve the bottle data from a dataframe created from a converted file.
 def retrieveBottleData(converted_df, debug=False):
     if BOTTLE_FIRE_COL_NAME in converted_df.columns:
+        converted_df['bottle_fire_num'] = ((converted_df[BOTTLE_FIRE_COL_NAME] == True) & (converted_df[BOTTLE_FIRE_COL_NAME] != converted_df[BOTTLE_FIRE_COL_NAME].shift(1))).astype(int).cumsum()
+        #converted_df['bottle_fire_num'] = ((converted_df[BOTTLE_FIRE_COL_NAME] == False)).astype(int).cumsum()
+
         return converted_df.loc[converted_df[BOTTLE_FIRE_COL_NAME] == True]
+        #return converted_df
     else:
         debugPrint("Bottle fire column:", BOTTLE_FIRE_COL_NAME, "not found")
     

--- a/converter_scaffolding.py
+++ b/converter_scaffolding.py
@@ -1,4 +1,5 @@
 import sys
+import csv
 import pandas as pd
 import sbe_reader as sbe_rd
 import sbe_equations_dict as sbe_eq
@@ -222,7 +223,7 @@ def convertFromSBEReader(sbeReader, debug=False):
             meta_df[metaArrayheaders[0][i]] = meta_df[metaArrayheaders[0][i]].astype(metaArrayheaders[1][i])
         else:
             meta_df[metaArrayheaders[0][i]] = meta_df[metaArrayheaders[0][i]].str.match('True', na=False)
-            debugPrint(meta_df[metaArrayheaders[0][i]].head())
+            #debugPrint(meta_df[metaArrayheaders[0][i]].head())
 
     debugPrint('Success!')
 
@@ -242,23 +243,77 @@ def importConvertedFile(fileName, debug=False):
     DEBUG = debug
 
     debugPrint("Importing data from:", fileName + '... ', end='')
-    output_df = pd.read_csv(fileName, index_col=0, parse_dates=False)
+    output_df = pd.read_csv(fileName, index_col=0, skiprows=[1], parse_dates=False)
+    #debugPrint(output_df.head())
     header_raw = output_df.columns.values.tolist()
-    header_type = [header.split('_')[-1] for header in header_raw]
+    header_type = []
 
-    for i, x in enumerate(header_type):
-        #debugPrint('Set', header_raw[i], 'to', header_type[i])
-        if header_type[i] == 'bool':
+    with open(fileName) as csvfile:
+        dtypeReader = csv.reader(csvfile, delimiter=',')
+        dtypeReader.__next__() # skip first row
+        dtype_header = dtypeReader.__next__() #second row
+        dtype_header.pop(0) #remove 'index' from left of dtype list
+        #debugPrint(dtype_header)
+
+    for i, x in enumerate(dtype_header):
+        #debugPrint('Set', header_raw[i], 'to', dtype_header[i])
+        if dtype_header[i] == 'bool_':
             d = {'True': True, 'False': False}
             output_df[header_raw[i]].map(d)
-
-        elif header_type[i] == 'datetime':
+        elif dtype_header[i] == 'datetime_':
             output_df[header_raw[i]] = output_df[header_raw[i]].astype('datetime64')
-
-        elif header_type[i] != 'index':
+        elif dtype_header[i] == 'int_':
+            output_df[header_raw[i]] = output_df[header_raw[i]].astype('int64')
+        elif dtype_header[i] == 'float_':
             output_df[header_raw[i]] = output_df[header_raw[i]].astype('float64')
 
     debugPrint("Done!")
 
     # return the imported data as a dataframe
     return output_df
+
+
+def saveConvertedDataToFile(converted_df, filename, debug=False):
+
+    # Save the bottle fire dataframe to file.
+    column_names = ['index']
+    column_names += converted_df.columns.tolist()
+    #debugPrint("Column Names:", ','.join(column_names))
+
+    datatype_names = ['index']
+    for column in converted_df.columns:
+
+        if converted_df[column].dtype.name == 'float64':
+            datatype_names.append('float_')
+        elif converted_df[column].dtype.name == 'datetime64[ns]':
+            datatype_names.append('datetime_')
+        elif converted_df[column].dtype.name == 'bool':
+            datatype_names.append('bool_')
+        elif converted_df[column].dtype.name == 'int64':
+            datatype_names.append('int_')
+        else:
+            datatype_names.append(converted_df[column].dtype.name)
+    #debugPrint("Datatypes Names:", ','.join(datatype_names))
+
+    # write the header and dtype rows to file
+    try:
+        with open(filename, 'w') as f:
+            f.write(','.join(column_names) + '\n')
+            f.write(','.join(datatype_names) + '\n')
+    except:
+        errPrint('ERROR: Could not save bottle fire data header to file')
+        return False
+    else:
+        debugPrint('Success!')
+
+    # write the contents of the dataframe to file
+    try:
+        converted_df.to_csv(filename, mode='a', header=False)
+    except:
+        errPrint('ERROR: Could not save bottle fire data to file')
+        return False
+    else:
+        debugPrint('Success!')
+
+    return True
+

--- a/run.py
+++ b/run.py
@@ -140,12 +140,10 @@ def main(argv):
     convertedfilePath = os.path.join(outputDir, convertedfileName)
 
     debugPrint('Saving converted data to:', convertedfilePath + '... ', end='')
-    try:
-        converted_df.to_csv(convertedfilePath)
-    except:
-        errPrint('ERROR: Could not save converted data to file')
-    else:
+    if cnv.saveConvertedDataToFile(converted_df, convertedfilePath, DEBUG):
         debugPrint('Success!')
+    else:
+        errPrint('ERROR: Could not save converted data to file')
 
 
     if args.iniFile:

--- a/sbe_reader.py
+++ b/sbe_reader.py
@@ -197,7 +197,7 @@ class SBEReader():
 
     def _breakdown_header(self):
         output = [
-            ['lat_ddeg', 'lon_ddeg', 'new_fix_bool', 'nmea_datetime', 'scan_datetime', 'btl_fire_bool'],
+            ['lat_ddeg', 'lon_ddeg', 'new_fix', 'nmea_datetime', 'scan_datetime', 'btl_fire'],
             ['float64', 'float64', 'bool_', 'datetime64', 'datetime64', 'bool_']
         ]
 


### PR DESCRIPTION
Based on feedback from Joseph and a closer inspection of 03401.cnv.csv in the repo the default behavior for how converted data is written to csv files was changed from a 1-line header to a 2-line header.

The first line of the header is the data type (pressure, temp, etc) '_' and the units of measure (mBar, C, etc)
The second line of the heard is the dtype to use when importing the data followed by '_' (int_, float_, bool_, datetime_)

The converted data import script (run.py) has been updated to accept this new format.

A new function (saveConvertedDataToFile()) has been added to converter_scaffolding.py.
This function requires a dataframe, filename and debug flag as arguments.  The function will write the dataframe to csv file with the new 2-line header format.

An updated version of the bottle.py (bottleNewStyle.py) has been added.  This file replicates the functions of bottle.py but utilizes the cnv import/export architecture. 